### PR TITLE
Add placeholder prediction API

### DIFF
--- a/madi resmi/server.js
+++ b/madi resmi/server.js
@@ -279,6 +279,10 @@ app.post('/api/help-request', async (req, res) => {
   }
 });
 
+// Заглушка для ML-прогноза
+app.post('/api/predict', (req, res) => {
+  res.json({ prediction: { prediction: '...', confidence: 0.0 } });
+});
 
 // Маршруты
 app.get('/help', (req, res) => {


### PR DESCRIPTION
## Summary
- add placeholder `/api/predict` route
- keep frontend pointing to new endpoint

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688697f616a88325956e247e33268a2c