### PR TITLE
Fix CSP directives in server.js

### DIFF
--- a/madi resmi/server.js
+++ b/madi resmi/server.js
@@ -20,13 +20,13 @@ app.use(cors());
 app.use(helmet({
   contentSecurityPolicy: {
     directives: {
-      defaultSrc: ["'self'",,"www.google.com"],
+      defaultSrc: ["'self'", "www.google.com"],
       scriptSrc: ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com","www.google.com","www.gstatic.com"],
       styleSrc: ["'self'", "'unsafe-inline'", "cdnjs.cloudflare.com","www.google.com"],
       imgSrc: ["'self'","'unsafe-inline'", "cdnjs.cloudflare.com", "data:","www.google.com","images.unsplash.com"],
       fontSrc: ["'self'","'unsafe-inline'", "cdnjs.cloudflare.com","www.google.com"],
       connectSrc: ["'self'","'unsafe-inline'", "cdnjs.cloudflare.com","www.google.com"],
-      frameSrc: ["'none'",,"'unsafe-inline'", "cdnjs.cloudflare.com","www.google.com"],
+      frameSrc: ["'none'", "'unsafe-inline'", "cdnjs.cloudflare.com", "www.google.com"],
       objectSrc: ["'none'","'unsafe-inline'", "cdnjs.cloudflare.com","www.google.com"]
     }
   }


### PR DESCRIPTION
## Summary
- fix stray commas in helmet CSP configuration

## Testing
- `grep -n ",," -n 'madi resmi/server.js'`


------
https://chatgpt.com/codex/tasks/task_e_688697f1eeac832587b8920ca6d99057